### PR TITLE
Do not mutate manifest_files while iterating over it

### DIFF
--- a/builder/__init__.py
+++ b/builder/__init__.py
@@ -38,7 +38,7 @@ def generate_manifest(script_dir, manifest_path, frozen_manifest, *addl_manifest
     if frozen_manifest is not None:
         manifest_files.append(f"include('{frozen_manifest}')")
 
-    manifest_files = [
+    frozen_manifest_files = [
         f'{script_dir}/driver/frozen/display/display_driver_framework.py',
         f'{script_dir}/driver/frozen/indev/touch_calibration/touch_cal_data.py',
         f'{script_dir}/driver/frozen/indev/touch_calibration/touch_calibrate.py',
@@ -51,7 +51,7 @@ def generate_manifest(script_dir, manifest_path, frozen_manifest, *addl_manifest
         f'{script_dir}/driver/frozen/other/task_handler.py'
     ]
 
-    for file in manifest_files:
+    for file in frozen_manifest_files:
         print(file)
         if not os.path.exists(file):
             raise RuntimeError(f'File not found "{file}"')


### PR DESCRIPTION
When running a `python make.py esp32 submodules mpy_cross BOARD=ESP32_GENERIC_S3` the building of the manifest file would fail with a `RunTimeError` exception as the entry `freeze('<path>', 'display_drive_framework.py')` could not be found. This occurred because the `manifest_files` list was being mutated while also being iterated through.