### PR TITLE
o_char and e_char are always empty, then returncode is None

### DIFF
--- a/builder/__init__.py
+++ b/builder/__init__.py
@@ -206,9 +206,12 @@ def spawn(cmd_, out_to_screen=True, spinner=False, env=None, cmpl=False, unix=Fa
         r_beg = False
         newline = False
         last_line_len = 0
+        o_char_seen = False
+        e_char_seen = False
         while p.poll() is None:
             o_char = p.stdout.read(1)
             while o_char != b'':
+                o_char_seen = True
                 output_buffer += o_char
                 if out_to_screen and not spinner and cmpl:
                     if o_char == b'\n':
@@ -263,6 +266,7 @@ def spawn(cmd_, out_to_screen=True, spinner=False, env=None, cmpl=False, unix=Fa
 
             e_char = p.stderr.read(1)
             while e_char != b'':
+                e_char_seen = True
                 if out_to_screen and not spinner:
                     try:
                         sys.stderr.write(e_char.decode('utf-8'))
@@ -275,7 +279,7 @@ def spawn(cmd_, out_to_screen=True, spinner=False, env=None, cmpl=False, unix=Fa
             if output_buffer.endswith(prompt):
                 break
 
-            if not e_char and not o_char:
+            if not e_char_seen and not o_char_seen:
                 break
 
         return output_buffer


### PR DESCRIPTION
by line 282 `o_char` and `e_char` are always empty
since `while o_char != b'':` and `while e_char != b'':` will have done their job

when this `break` is executed, it might be that `p.poll()` has not yet filled in the [returncode](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.returncode)
This might result in all kind of strange behavior if the result of `spawn` is checked and found to be `None` in stead of `0`

Same concern for the break for prompt.
Maybe after `o_buf = read()` a call should be added `p.wait()` to ensure the child process has terminated?