### PR TITLE
Adds new command line parameters and removes the need to use "python3" in the build command

### DIFF
--- a/make.py
+++ b/make.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import builder


### PR DESCRIPTION
*  adds marker in make.py that will allow for running the build without having to specifically enter "python3"

   `make.py esp32 clean BOARD=ESP32_GENERIC`

   instead of

   `python3 make.py esp32 clean BOARD=ESP32_GENERIC`

* There are variants of the esp32-s3 that have 4mb, 8mb, 16mb and 32mb flash and that is what using --flash-size=? allows us to set.

   The --octal-flash you have to add if the flash uses octal SPI. This is seen with the 32mb flash size. There are some changes that need to occur in order for the flash to work properly. So if you have an esp32-s3 N32R8 you will want to use the following build command

   ``` 
   make.py esp32 clean submodules mpy_cross BOARD=ESP32_GENERIC_S3 BOARD_VARIANT=SPIRAM_OCT --octal-flash --flash-size=32
   ```